### PR TITLE
feat: add automated release workflow with cross-platform builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,4 @@ jobs:
       run: cargo fmt -- --check
     - name: Run clippy
       run: cargo clippy -- -D warnings
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: Build & Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu,x86_64-pc-windows-gnu
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Install cross-compilation dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-mingw-w64-x86-64
+
+      - name: Release build for all targets
+        run: just release-all
+
+      - name: Package binaries
+        run: |
+          mkdir -p release
+          # Linux binary
+          cp target/x86_64-unknown-linux-gnu/release/raindrop-mcp-server release/raindrop-mcp-server-linux
+          tar czf release/raindrop-mcp-server-${{ github.ref_name }}-linux.tar.gz -C release raindrop-mcp-server-linux
+          # Windows binary
+          cp target/x86_64-pc-windows-gnu/release/raindrop-mcp-server.exe release/raindrop-mcp-server-windows.exe
+          zip -j release/raindrop-mcp-server-${{ github.ref_name }}-windows.zip release/raindrop-mcp-server-windows.exe
+
+      - name: Upload Linux artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: raindrop-mcp-server-linux-${{ github.ref_name }}
+          path: release/raindrop-mcp-server-${{ github.ref_name }}-linux.tar.gz
+
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: raindrop-mcp-server-windows-${{ github.ref_name }}
+          path: release/raindrop-mcp-server-${{ github.ref_name }}-windows.zip
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Linux artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: raindrop-mcp-server-linux-${{ github.ref_name }}
+
+      - name: Download Windows artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: raindrop-mcp-server-windows-${{ github.ref_name }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          files: |
+            raindrop-mcp-server-${{ github.ref_name }}-linux.tar.gz
+            raindrop-mcp-server-${{ github.ref_name }}-windows.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "raindrop-mcp-server-rs"
+name = "raindrop-mcp-server"
 version         = "0.1.0"
 edition         = "2024"
 rust-version    = "1.85"
 authors         = ["Yamahigashi <yamahigashi@gmail.com>"]
-description = "A Rust implementation of the Raindrop MCP server, providing a protocol for managing and interacting with Raindrop bookmarks."
+description     = "A Rust implementation of the Raindrop MCP server, providing a protocol for managing and interacting with Raindrop bookmarks."
 license         = "MIT"
 repository      = "https://github.com/yamahigashi/raindrop-mcp-server-rs"
 homepage        = "https://github.com/yamahigashi/raindrop-mcp-server-rs"

--- a/justfile
+++ b/justfile
@@ -13,3 +13,26 @@ test:
 
 cov:
     cargo llvm-cov --lcov --output-path {{justfile_directory()}}/target/llvm-cov-target/coverage.lcov
+
+# Cross-compilation setup
+setup-targets:
+    rustup target add x86_64-unknown-linux-gnu
+    rustup target add x86_64-pc-windows-gnu
+
+# Build for Linux (glibc)
+build-linux:
+    cargo build --target x86_64-unknown-linux-gnu --release
+
+# Build for Windows (GNU toolchain)
+build-windows-gnu:
+    cargo build --target x86_64-pc-windows-gnu --release
+
+
+# Build for all targets
+build-all: build-linux build-windows-gnu
+
+# Cross-compile release builds for distribution
+release-all: setup-targets build-all
+    @echo "Release builds completed:"
+    @echo "Linux (glibc): target/x86_64-unknown-linux-gnu/release/raindrop-mcp-server"
+    @echo "Windows (GNU): target/x86_64-pc-windows-gnu/release/raindrop-mcp-server.exe"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use raindrop_mcp_server_rs::mcp::McpServer;
+use raindrop_mcp_server::mcp::McpServer;
 use rmcp::{ServiceExt, transport::stdio};
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for automated releases triggered by version tags
- Implement cross-compilation support for Linux and Windows platforms in justfile
- Standardize package name to `raindrop-mcp-server` across all configuration files
- Update import paths to match the new package structure

## Changes
- **New GitHub Actions workflow** (`.github/workflows/release.yml`):
  - Automated build and release on `v*.*.*` tags
  - Cross-platform builds for Linux (x86_64-unknown-linux-gnu) and Windows (x86_64-pc-windows-gnu)
  - Uses `just` for consistent build process
  - Packages binaries as tar.gz (Linux) and zip (Windows)
  - Creates GitHub releases with binary attachments

- **Enhanced justfile**:
  - Added cross-compilation targets setup
  - Added platform-specific build commands
  - Added `release-all` command for distribution builds

- **Package name consistency**:
  - Updated `Cargo.toml` package name to `raindrop-mcp-server`
  - Fixed import paths in `src/main.rs`
  - Corrected binary names in justfile output messages

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Test cross-compilation builds locally with `just release-all`
- [ ] Confirm import paths work correctly with `cargo check`
- [ ] Test release workflow by creating a test tag (after merge)

🤖 Generated with [Claude Code](https://claude.ai/code)